### PR TITLE
Free cassandra futures

### DIFF
--- a/src/cql_ffi/future/prepared_future.rs
+++ b/src/cql_ffi/future/prepared_future.rs
@@ -7,6 +7,7 @@ use cql_bindgen::CassFuture as _CassFuture;
 use cql_ffi::prepared::CassPrepared;
 use cql_ffi::error::CassError;
 
+use cql_bindgen::cass_future_free;
 use cql_bindgen::cass_future_wait;
 use cql_bindgen::cass_future_get_prepared;
 use cql_bindgen::cass_future_error_message;
@@ -14,7 +15,17 @@ use cql_bindgen::cass_future_error_code;
 
 pub struct PreparedFuture(pub *mut _CassFuture);
 
+impl Drop for PreparedFuture {
+    fn drop(&mut self) {unsafe{
+        self.free()
+    }}
+}
+
 impl PreparedFuture {
+    unsafe fn free(&mut self) {
+        cass_future_free(self.0)
+    }
+
     pub fn wait(&mut self) -> Result<CassPrepared,CassError> {unsafe{cass_future_wait(self.0);self.error_code()}}
 
     pub fn error_code(&mut self) -> Result<CassPrepared,CassError> {unsafe{

--- a/src/cql_ffi/future/result_future.rs
+++ b/src/cql_ffi/future/result_future.rs
@@ -7,6 +7,7 @@ use cql_bindgen::CassFuture as _CassFuture;
 use cql_ffi::error::CassError;
 use cql_ffi::result::CassResult;
 
+use cql_bindgen::cass_future_free;
 use cql_bindgen::cass_future_wait;
 use cql_bindgen::cass_future_error_code;
 use cql_bindgen::cass_future_error_message;
@@ -14,7 +15,17 @@ use cql_bindgen::cass_future_get_result;
 
 pub struct ResultFuture(pub *mut _CassFuture);
 
+impl Drop for ResultFuture {
+    fn drop(&mut self) {unsafe{
+        self.free()
+    }}
+}
+
 impl ResultFuture {
+    unsafe fn free(&mut self) {
+        cass_future_free(self.0)
+    }
+
     pub fn wait(&mut self) -> Result<CassResult,CassError> {unsafe{
         cass_future_wait(self.0);self.error_code()
     }}

--- a/src/cql_ffi/future/session_future.rs
+++ b/src/cql_ffi/future/session_future.rs
@@ -1,12 +1,20 @@
 use cql_ffi::error::CassError;
 use cql_ffi::session::CassSession;
 use cql_bindgen::CassFuture as _CassFuture;
+use cql_bindgen::cass_future_free;
 use cql_bindgen::cass_future_wait;
 use cql_bindgen::cass_future_error_code;
 
 pub struct SessionFuture(pub *mut _CassFuture, pub CassSession);
 
 impl SessionFuture {
-    pub fn wait(self) -> Result<CassSession,CassError> {unsafe{cass_future_wait(self.0);self.error_code()}}
-    unsafe fn error_code(self) -> Result<CassSession,CassError> {CassError::build(cass_future_error_code(self.0)).wrap(self.1)}
+    pub fn wait(self) -> Result<CassSession,CassError> {unsafe{
+        cass_future_wait(self.0);
+        self.error_code()
+    }}
+    unsafe fn error_code(self) -> Result<CassSession,CassError> {
+        let code = cass_future_error_code(self.0);
+        cass_future_free(self.0);
+        CassError::build(code).wrap(self.1)
+    }
 }


### PR DESCRIPTION
As reported in #4, these were leaked previously. With this patch in place
memory usage is constant, and valgrind is happy.

The session future needed some different handling due to its move return.

I wonder if it would make sense to implement `Drop` directly on `cql_bindgen::CassFuture` instead, as that would cover all these cases.