### PR TITLE
Implement vector bytes type

### DIFF
--- a/src/cassandra/column.rs
+++ b/src/cassandra/column.rs
@@ -281,6 +281,25 @@ impl Column {
         }
     }
 
+    /// Gets the blog from this column or errors if type if wrong
+    pub fn get_blob(&self) -> Result<Vec<u8>, CassError> {
+        unsafe {
+            match cass_value_type(self.0) {
+                CASS_VALUE_TYPE_BLOB => {
+                    let mut message = mem::zeroed();
+                    let mut message_length = mem::zeroed();
+                    match cass_value_get_string(self.0, &mut message, &mut message_length) {
+                        CASS_OK => {
+                            Ok(Vec::from(slice::from_raw_parts(message as *const u8, message_length as usize)))
+                        }
+                        err => Err(CassError::build(err)),
+                    }
+                }
+                _ => panic!("Value type is not BLOB")
+            }
+        }
+    }
+
     ///Gets the i32 from this column or errors if you ask for the wrong type
     pub fn get_i32(&self) -> Result<i32, CassError> {
         unsafe {

--- a/src/cassandra/row.rs
+++ b/src/cassandra/row.rs
@@ -167,6 +167,19 @@ impl AsRustType<MapIterator> for Row {
     }
 }
 
+impl AsRustType<Vec<u8>> for Row {
+    fn get_col(&self, index: usize) -> Result<Vec<u8>, CassError> {
+        let col = try!(self.get_column(index));
+        col.get_blob()
+    }
+
+    fn get_col_by_name<S>(&self, name: S) -> Result<Vec<u8>, CassError>
+        where S: Into<String> {
+        let col = try!(self.get_column_by_name(name));
+        col.get_blob()
+    }
+}
+
 impl Row {
     ///Get a particular column by index
     pub fn get_column(&self, index: usize) -> Result<Column, CassError> {

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -215,6 +215,15 @@ impl BindRustType<Map> for Statement {
     }
 }
 
+impl BindRustType<Vec<u8>> for Statement {
+    fn bind(&mut self, index: usize, value: Vec<u8>) -> Result<&mut Self, CassError> {
+        self.bind_bytes(index, value)
+    }
+
+    fn bind_by_name(&mut self, col: &str, value: Vec<u8>) -> Result<&mut Self, CassError> {
+        self.bind_bytes_by_name(col, value)
+    }
+}
 
 impl Statement {
     ///Creates a new query statement.


### PR DESCRIPTION
In favor of https://github.com/tupshin/cassandra-rs/pull/34

Implemented blob type which I use to get raw bytes from cassandra table then decode it from snappy for later use. 